### PR TITLE
Code quality fix - Parsing should be used to convert "Strings" to primitives.

### DIFF
--- a/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/demo/widgets/ProgressBarWidget.java
+++ b/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/demo/widgets/ProgressBarWidget.java
@@ -115,12 +115,12 @@ public class ProgressBarWidget extends WidgetGroup implements ICustomWidget {
         this.atlasName = attributeMap.get("atlas");
         this.backgroundImageFrame = attributeMap.get("bgImageFrame");
         this.progressImageFrame = attributeMap.get("progressImageFrame");
-        this.ninePatchLeft = Integer.valueOf(attributeMap.get("ninePatchLeft"));
-        this.ninePatchRight = Integer.valueOf(attributeMap.get("ninePatchRight"));
-        this.progressImagePaddingLeft = Float.valueOf(attributeMap.get("progressImagePaddingLeft")) * sizeMult;
-        this.progressImagePaddingRight = Float.valueOf(attributeMap.get("progressImagePaddingRight")) * sizeMult;
+        this.ninePatchLeft = Integer.parseInt(attributeMap.get("ninePatchLeft"));
+        this.ninePatchRight = Integer.parseInt(attributeMap.get("ninePatchRight"));
+        this.progressImagePaddingLeft = Float.parseFloat(attributeMap.get("progressImagePaddingLeft")) * sizeMult;
+        this.progressImagePaddingRight = Float.parseFloat(attributeMap.get("progressImagePaddingRight")) * sizeMult;
         this.text = attributeMap.get("text");
-        this.completeDuration = Float.valueOf(attributeMap.get("duration"));
+        this.completeDuration = Float.parseFloat(attributeMap.get("duration"));
         this.fontName = attributeMap.get("fontName");
     }
 

--- a/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/xml/XmlHelper.java
+++ b/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/xml/XmlHelper.java
@@ -15,7 +15,7 @@ public class XmlHelper {
 		if (sValue == null) {
 			return defaultValue;
 		}
-		return Float.valueOf(sValue);
+		return Float.parseFloat(sValue);
 	}
 
 	public static int readIntAttribute(XmlPullParser parser, String attributeName, int defaultValue) {
@@ -23,7 +23,7 @@ public class XmlHelper {
 		if (sValue == null) {
 			return defaultValue;
 		}
-		return Integer.valueOf(sValue);
+		return Integer.parseInt(sValue);
 	}
 
 	public static String readStringAttribute(XmlPullParser parser, String attributeName) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2130 - Parsing should be used to convert "Strings" to primitives.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2130

Please let me know if you have any questions.

Faisal Hameed