### PR TITLE
General code quality fix-1

### DIFF
--- a/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/assets/Assets.java
+++ b/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/assets/Assets.java
@@ -74,7 +74,8 @@ public class Assets implements AssetsInterface {
 
     @Override
     public void unloadAssets(String key) {
-        this.assetLoader.unloadAssets(key, Collections.EMPTY_SET);
+        Set<String> emptySet = Collections.emptySet();
+        this.assetLoader.unloadAssets(key, emptySet);
     }
 
     @Override

--- a/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/util/GdxUtils.java
+++ b/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/util/GdxUtils.java
@@ -8,6 +8,10 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 
 public class GdxUtils {
 
+    private GdxUtils() {
+        
+    }
+    
     private static GlyphLayout glyphLayout = new GlyphLayout();
 
     public static String trim( String text, float width, BitmapFont font){

--- a/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/util/Utils.java
+++ b/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/util/Utils.java
@@ -7,6 +7,11 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class Utils {
+    
+    private Utils() {
+        
+    }
+    
 	public static boolean checkMD5(String md5, InputStream is) {
 		if (md5 == null || md5.equals("") || is == null) {
 			return false;

--- a/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/widgets/listwidget/ListWidgetAdapter.java
+++ b/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/widgets/listwidget/ListWidgetAdapter.java
@@ -11,7 +11,7 @@ import java.util.List;
  */
 public abstract class ListWidgetAdapter<T> implements IListWidgetAdapter<T> {
 
-    protected List<T> items = Collections.EMPTY_LIST;
+    protected List<T> items = Collections.emptyList();
     protected ListWidgetDataSetChangeListener dataSetChangeListener;
     protected StageBuilder stageBuilder;
 

--- a/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/xml/XmlHelper.java
+++ b/core/src/main/java/net/peakgames/libgdx/stagebuilder/core/xml/XmlHelper.java
@@ -10,6 +10,10 @@ import java.io.InputStream;
 
 public class XmlHelper {
 
+    private XmlHelper() {
+        
+    }
+    
 	public static float readFloatAttribute(XmlPullParser parser, String attributeName, float defaultValue) {
 		String sValue = parser.getAttributeValue(null, attributeName);
 		if (sValue == null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of 
Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET. 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1596
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed